### PR TITLE
Tapping a bus ID that's already selected doesn't trigger haptic feedback

### DIFF
--- a/Shared/Views/BusOption.swift
+++ b/Shared/Views/BusOption.swift
@@ -17,9 +17,11 @@ struct BusOption: View {
 	
 	var body: some View {
 		Button {
-			withAnimation {
-				self.feedbackGenerator.selectionChanged()
-				self.selectedBusID = self.busID
+			if self.selectedBusID != self.busID {
+				withAnimation {
+					self.feedbackGenerator.selectionChanged()
+					self.selectedBusID = self.busID
+				}
 			}
 		} label: {
 			Text("\(self.busID.rawValue)")


### PR DESCRIPTION
Only trigger haptic feedback if bus selection button's busID is not the same as the currently selected busID.

Closes #26 