### PR TITLE
Settings view

### DIFF
--- a/Shared/Views/SettingsView.swift
+++ b/Shared/Views/SettingsView.swift
@@ -14,29 +14,25 @@ struct SettingsView: View {
 	@EnvironmentObject private var sheetStack: SheetStack
 	
 	@AppStorage("ColorBlindMode") private var colorBlindMode = false
-    
-    
 	
 	var body: some View {
 		SheetPresentationWrapper {
 			Form {
 				#if os(iOS)
 				Section {
-                    HStack {
-                        ZStack {
-                            Circle()
-                                .fill(.green)
-                            Image(systemName: self.colorBlindMode ? "scope" : "bus")
-                                .resizable()
-                                .frame(width: 15, height: 15)
-                                .foregroundColor(.white)
-                        }
-                            .frame(width: 30)
-                        Toggle("Color-Blind Mode", isOn: self.$colorBlindMode)
-                    }
-                        .frame(height: 30)
-        
-					
+					HStack {
+						ZStack {
+							Circle()
+								.fill(.green)
+							Image(systemName: self.colorBlindMode ? "scope" : "bus")
+								.resizable()
+								.frame(width: 15, height: 15)
+								.foregroundColor(.white)
+						}
+							.frame(width: 30)
+						Toggle("Color-Blind Mode", isOn: self.$colorBlindMode)
+					}
+						.frame(height: 30)
 				} footer: {
 					Text("Modifies bus markers so that they’re distinguishable by icon in addition to color.")
 				}

--- a/Shared/Views/SettingsView.swift
+++ b/Shared/Views/SettingsView.swift
@@ -14,13 +14,29 @@ struct SettingsView: View {
 	@EnvironmentObject private var sheetStack: SheetStack
 	
 	@AppStorage("ColorBlindMode") private var colorBlindMode = false
+    
+    
 	
 	var body: some View {
 		SheetPresentationWrapper {
 			Form {
 				#if os(iOS)
 				Section {
-					Toggle("Color-Blind Mode", isOn: self.$colorBlindMode)
+                    HStack {
+                        ZStack {
+                            Circle()
+                                .fill(.green)
+                            Image(systemName: self.colorBlindMode ? "scope" : "bus")
+                                .resizable()
+                                .frame(width: 15, height: 15)
+                                .foregroundColor(.white)
+                        }
+                            .frame(width: 30)
+                        Toggle("Color-Blind Mode", isOn: self.$colorBlindMode)
+                    }
+                        .frame(height: 30)
+        
+					
 				} footer: {
 					Text("Modifies bus markers so that they’re distinguishable by icon in addition to color.")
 				}

--- a/Shared/Views/WhatsNewSheet.swift
+++ b/Shared/Views/WhatsNewSheet.swift
@@ -49,7 +49,7 @@ struct WhatsNewSheet: View {
 					Text("Navigation")
 						.font(.headline)
 						.padding(.top)
-					Text("We’ve significantly improved the app navigation structure, so it’s now much easier to find information and additional functionality.")
+					Text("We’ve significantly improved the app’s navigation structure, so it’s now much easier to find information and additional functionality.")
 					Text("Permissions")
 						.font(.headline)
 						.padding(.top)


### PR DESCRIPTION
Added in bus icon that updates/changes in live time when a user toggles color-blind mode. Needs some styling, but I thought that it might be helpful to see the differences.